### PR TITLE
Remove semicolons

### DIFF
--- a/src/sass/index.sass
+++ b/src/sass/index.sass
@@ -91,9 +91,9 @@ $accordion-content-pre-code-background-color: transparent !default
           right: 0
           bottom: 0
           content: '\002B'
-          line-height: 0;
-          justify-content: center;
-          align-items: center;
+          line-height: 0
+          justify-content: center
+          align-items: center
         &::after
           display: none
       & + .accordion-body


### PR DESCRIPTION
Semicolons aren't allowed in the indented syntax. Fixes an error that is thrown when trying to compile using sass-loader v7.